### PR TITLE
School pride: update colors to white and lime green, add Octodex mascot

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,9 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+  <img src="https://octodex.github.com/images/Professortocat_v2.png" alt="Mascotte Octodex" height="100" style="float:right; margin-left:20px;" />
+  <h1>Mergington High School</h1>
+  <h2>Extracurricular Activities</h2>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -12,14 +12,14 @@ body {
   max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
-  background-color: #f5f5f5;
+  background-color: white;
 }
 
 header {
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
-  background-color: #1a237e;
+  background-color: #32CD32;
   color: white;
   border-radius: 5px;
 }
@@ -54,7 +54,7 @@ section h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
-  color: #1a237e;
+  color: #32CD32;
 }
 
 .activity-card {
@@ -67,7 +67,7 @@ section h3 {
 
 .activity-card h4 {
   margin-bottom: 10px;
-  color: #0066cc;
+  color: #32CD32;
 }
 
 .activity-card p {
@@ -150,7 +150,7 @@ section h3 {
 }
 
 button {
-  background-color: #1a237e;
+  background-color: #32CD32;
   color: white;
   border: none;
   padding: 10px 15px;
@@ -161,7 +161,7 @@ button {
 }
 
 button:hover {
-  background-color: #3949ab;
+  background-color: #228B22;
 }
 
 .message {


### PR DESCRIPTION
Ce pull request résout l'issue #2 :
- Les couleurs principales du site sont maintenant blanc et vert lime (couleurs de l'école).
- Une mascotte Octodex est ajoutée sur la page d'accueil.

Merci de vérifier le rendu visuel et l'identité graphique.